### PR TITLE
[ffmpeg] 4.4 Enable Opus codec via libopus

### DIFF
--- a/rpm/ffmpeg.spec
+++ b/rpm/ffmpeg.spec
@@ -10,6 +10,7 @@ License:        LGPLv2+
 BuildRequires:  pkgconfig(libopenjp2)
 BuildRequires:  pkgconfig(libpulse)
 BuildRequires:  pkgconfig(libwebp)
+BuildRequires:  pkgconfig(opus)
 BuildRequires:  pkgconfig(speex)
 BuildRequires:  pkgconfig(theora)
 BuildRequires:  pkgconfig(vorbis)
@@ -51,7 +52,7 @@ sed -i 's/sed -E/sed -r/g' ./configure
 ./configure --prefix=/usr --libdir=%{_libdir} --disable-debug --enable-shared --enable-pic \
   --disable-static --disable-doc --enable-muxers --enable-demuxers --enable-protocols \
   --disable-indevs --disable-outdevs --disable-bsfs --enable-network --disable-hwaccels \
-  --enable-libopenjpeg --enable-libpulse --enable-libspeex --enable-libtheora \
+  --enable-libopenjpeg --enable-libopus --enable-libpulse --enable-libspeex --enable-libtheora \
   --enable-libvorbis --enable-libvpx --enable-libwebp --disable-encoders --disable-decoders \
   --enable-encoder="$(perl -pe 's{^(\w*).*}{$1,}gs' <%{SOURCE2})" \
   --enable-decoder="$(perl -pe 's{^(\w*).*}{$1,}gs' <%{SOURCE1})" \


### PR DESCRIPTION
While ffmpeg has their own internal `opus` codec, they recommend using
libopus, at least for encoding.

https://ffmpeg.org/ffmpeg-codecs.html#opus
